### PR TITLE
Fix Symfony 4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 
     "require": {
         "php": "^7.1",
-        "symfony/framework-bundle": "^5.0",
+        "symfony/framework-bundle": "^5.0|^4.0",
         "acelaya/doctrine-enum-type": "^2.3"
     },
 


### PR DESCRIPTION
Adding the Symfony 5 support results in Symfony 4-based projects being unable to install this bundle. As far as I know, nothing changed in the code, so I presume it's still compatible.

This pull request allows both 4 and 5.